### PR TITLE
design:State.js Components width, height에 맞춰 다시 정렬

### DIFF
--- a/cd-gq/src/components/InputDate.js
+++ b/cd-gq/src/components/InputDate.js
@@ -114,7 +114,7 @@ const Button=styled.button`
 
     background:none;
     border:none;
-    border-radius:50%
+    border-radius:50%;
 
     display:flex;
     align-items:center;
@@ -122,7 +122,7 @@ const Button=styled.button`
 
     cursor:pointer;
 
-    &:hover:{
+    &:hover{
         background-color:${({theme})=>theme.colors.darkblue};
     }
 

--- a/cd-gq/src/components/State.js
+++ b/cd-gq/src/components/State.js
@@ -27,10 +27,13 @@ const Container=styled.div`
     flex-direction: column;
     justify-content: flex-start;
 
-    padding:25px;
+    width:330px;
+
+    padding:3vw;
 
     flex-wrap: wrap;
-    gap:25px;
+    /* gap:25px; */
+    gap:3vw;
 
     color:${({theme})=>theme.colors.white};
     background-color: ${({theme})=>theme.colors.red};
@@ -58,8 +61,12 @@ const Body=styled.div`
     align-items: center;
     justify-content: space-between;
 
-    flex-wrap:wrap;
-    gap:30px;
+    width:100%;
+    height:100%;
+
+    /* flex-wrap:wrap; */
+    /* gap:30px; */
+    gap:0.25vw;
     margin-bottom: 15px;
   
     font-weight: ${({theme})=>theme.fontsWeights.state};
@@ -106,10 +113,12 @@ const GotoDetail=styled.button`
     align-items: center;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap:15px;
+    gap:10px;
 
     margin-top:10px;
     padding:18px 38px;
+
+    width: 100%;
 
     background-color: ${({theme})=>theme.colors.white};
     border-radius: 50px;

--- a/cd-gq/src/components/TestDate.js
+++ b/cd-gq/src/components/TestDate.js
@@ -11,45 +11,25 @@ import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 import 'react-date-range/dist/styles.css'; // main style file
 import 'react-date-range/dist/theme/default.css'; // theme css file
 
-// import { addDays } from 'date-fns';
-
-// const TestDate=()=>{
-//     const [state, setState] = useState([
-//         {
-//           startDate: new Date(),
-//           endDate: null,
-//           key: 'selection'
-//         }
-//       ]);
-      
-//     return(
-//         <>
-//             <Container>
-//                 <DateRange
-//                     editableDateInputs={true}
-//                     onChange={item => setState([item.selection])}
-//                     moveRangeOnFirstSelection={false}
-//                     ranges={state}
-//                 />
-//             </Container>
-            
-//         </>
-//     )
-// }
-
 const Container=styled.div`
     display:flex;
     justify-content:center;
     text-align:center;
-    align-item:center;
-
-    // color:${({theme})=>theme.colors.mainPageColor};
-    // background-color:${({theme})=>theme.colors.darkblue};
+    align-items:center ;
+    //전체 Container에서 color 
+    color: ${({theme})=>theme.colors.darkblue};
 
     .testCode{
-        // background-color:${({theme})=>theme.colors.white};
-        background-color:${({theme})=>theme.colors.yellow};
+        background-color:${({theme})=>theme.colors.white};
+        display: flex;
+        flex-direction: column;
+
+        /* justify-content: center;
+        align-items: center; */
+
+        width: 100%;
         border-radius:15px;
+        box-shadow:0px 3px 5px #0000002f;
     }
 `;
 
@@ -70,7 +50,9 @@ const TestDate = () => {
                     editableDateInputs={false} // 날짜 입력 불가능하도록 설정
                     onChange={item => setState([item.selection])}
                     moveRangeOnFirstSelection={false}
+                    // 얘가 위에 기간을 없애줌
                     ranges={state}
+
                 />
             </Container>
 

--- a/cd-gq/src/pages/Home.js
+++ b/cd-gq/src/pages/Home.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components';
 import Header from '../components/Header';
+import State from '../components/State';
 
 const Background = styled.div`
   display: flex;
@@ -29,6 +30,7 @@ function Home() {
   return (
     <Background>
       <Header/>
+      <State />
       <Button onClick={() => navigate('/')}>사이트맵으로 가기</Button>
     </Background>
   )


### PR DESCRIPTION
## Changes 📝

<!-- 이 PR에서 작업한 사항을 적어주세요. -->

- State width를 330px로 수정하면서 요소들 정렬도 다시 정렬함
- InputDate 달력 요소 수정

## Issues 🚩

<!-- 이 PR과 연관된 Issue를 작성해주세요. 해당 PR이 Issue를 해결한다면 Issue도 꼭 닫아주세요! 연관 Issue가 없다면 작성하지 않으셔도 됩니다. -->

> 다시 수정 필요

## Screenshot 📷

<!-- 작업한 사항을 스크린샷으로 찍을 수 있다면 (예: 신규 페이지 구현, 새로운 컴포넌트 구현) 스크린샷을 찍어서 올려주세요. 반드시 올릴 필요는 없습니다! -->
<img width="1266" alt="image" src="https://github.com/CapstoneDesign24-GQ/FE/assets/126383608/a0b7361f-707e-4c1f-8243-f947dfd76cb3">

## To do Next ➡️

<!-- 다음에 진행할 업무에 대해서 적어주세요. -->

- width 다시 수정하기
